### PR TITLE
Fix

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -479,8 +479,8 @@ static bool check_address(void *addr) {
     if (cur->pml4 == NULL) {
         return false;
     }
-
-    void *page = pml4_get_page(cur->pml4, addr);
+    
+    void *page = spt_find_page(&cur->spt,pg_round_down(addr));
     if (page == NULL) {
         return false;
     }


### PR DESCRIPTION
유효주소 검사 함수 내부 변경

기존 : pml4_get_page() 함수로 유저 가상 주소가 실제 메모리 주소와 매핑되어 있는지 검사

변경: spt_find_page() 함수로 spt 테이블 내에 있는지만 검사

[FAIL -> PASS]
read-boundary
write-normal 