### PR TITLE
feat : `spt_kill` , `uninit_destroy`

### DIFF
--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -61,7 +61,16 @@ static bool uninit_initialize(struct page *page, void *kva) {
  * exit, which are never referenced during the execution.
  * PAGE will be freed by the caller. */
 static void uninit_destroy(struct page *page) {
-    struct uninit_page *uninit UNUSED = &page->uninit;
+    struct uninit_page *uninit = &page->uninit;
     /* TODO: Fill this function.
      * TODO: If you don't have anything to do, just return. */
+
+     /* [08.06] Page Cleaup 수행 
+        한번도 사용 되지 않은 uninit 페이지 -> aux만 free
+     */
+     if (uninit->aux !=NULL)
+     {
+        free(uninit->aux);
+     }
+
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -15,7 +15,7 @@
 unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED);
 bool page_less(const struct hash_elem *a_, 
                 const struct hash_elem *b_, void *aux UNUSED);
-
+void destroy_hash_entry(struct hash_elem *e);
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -284,22 +284,42 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
 }
 
 /* Free the resource hold by the supplemental page table */
-void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
+void supplemental_page_table_kill(struct supplemental_page_table *spt) {
     /* TODO: Destroy all the supplemental_page_table hold by thread and
      * TODO: writeback all the modified contents to the storage. */
+
+    // SPT 를 순회하면서 destroy(page) 
+    struct hash_iterator i;
+
+    // iterator 를 해시테이블 첫 원소의 앞으로 이동
+    hash_first(&i,&spt->pages);
+
+    // 해시테이블의 모든 원소를 삭제 
+    // hash_clear 내부에서 destroy_hash_entry 를 모든 원소마다 해주는듯
+    hash_clear (&spt->pages , destroy_hash_entry);
+
 }
 
-/* ===== 해시 함수 추가 부분 08.04 ===== */
+/* ===== [08.04]해시 함수 추가 부분 ===== */
 unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED){
     const struct page *p = hash_entry(p_,struct page, hash_elem);
     return hash_bytes(&p->va,sizeof (p->va));
 }
 
-/* ===== 해시 함수 추가 부분 08.04 ===== */
+/* ===== [08.04] 해시 함수 추가 부분 ===== */
 bool page_less(const struct hash_elem *a_, 
                 const struct hash_elem *b_, void *aux UNUSED){
     const struct page *a =hash_entry(a_,struct page,hash_elem);
     const struct page *b =hash_entry(b_,struct page, hash_elem);
                 
     return a->va < b-> va;
+}
+
+/* ===== [08.06] 해시 테이블 엔트리 destroy ===== */
+void destroy_hash_entry(struct hash_elem *e)
+{
+    struct page *p = hash_entry(e,struct page,hash_elem);
+
+    //페이지 타입에 맞게 uninit_destroy / anon_destroy 호출 
+    destroy(p);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -296,7 +296,7 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt) {
 
     // 해시테이블의 모든 원소를 삭제 
     // hash_clear 내부에서 destroy_hash_entry 를 모든 원소마다 해주는듯
-    hash_clear (&spt->pages , destroy_hash_entry);
+    hash_destroy(&spt->pages , destroy_hash_entry);
 
 }
 


### PR DESCRIPTION
## 1. `supplemental_page_table_kill` in `vm.c`

```c
void supplemental_page_table_kill(struct supplemental_page_table *spt) {

    // SPT 를 순회하면서 destroy(page) 호출 
    struct hash_iterator i;

    // iterator 를 해시테이블 첫 원소의 앞으로 이동
    hash_first(&i,&spt->pages);

    // 해시테이블의 모든 원소를 삭제 -> destroy_hash_entry 를 모든 원소마다 해주는듯
    hash_clear (&spt->pages , destroy_hash_entry);

}

/* ===== [08.06] 해시 테이블 엔트리 destroy ===== */
void destroy_hash_entry(struct hash_elem *e)
{
    struct page *p = hash_entry(e,struct page,hash_elem);

    destroy(p);
 
}
```

## 2.  `uninit_destroy` in `uninit.c`

```c
static void uninit_destroy(struct page *page) {
    struct uninit_page *uninit = &page->uninit;
    /* TODO: Fill this function.
     * TODO: If you don't have anything to do, just return. */

     /* [08.06] Page Cleaup 수행 
        한번도 사용 되지 않은 uninit 페이지 -> aux만 free
     */
     if (uninit->aux !=NULL)
     {
        free(uninit->aux);
     }

}
```

---

좀 더 공부해야 할 것 같은데, 확인 부탁드립니다

---

### Fix 

`hash_clear` ->` hash_destroy `로 변경했습니다.
