### PR TITLE
vm_stack_growth 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -179,7 +179,7 @@ static struct frame *vm_get_frame(void) {
 }
 
 /* Growing the stack. */
-static void vm_stack_growth(void *addr UNUSED) {
+static void vm_stack_growth(void *addr) {
     // 스택 확장을 위한 익명페이지 할당
     // 페이지폴트 발생 주소를 round down
     vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, pg_round_down(addr), true, NULL, NULL);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -181,8 +181,12 @@ static struct frame *vm_get_frame(void) {
 /* Growing the stack. */
 static void vm_stack_growth(void *addr) {
     // 스택 확장을 위한 익명페이지 할당
-    // 페이지폴트 발생 주소를 round down
-    vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, pg_round_down(addr), true, NULL, NULL);
+    // 페이지폴트 발생 주소를 round down -> 이미 존재하는 페이지 도달할 때까지 확장
+    void *c_addr;
+    for (c_addr = pg_round_down(addr); ; c_addr += PGSIZE)
+        if (!vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, c_addr, true, NULL, NULL)){
+            break;
+    };
 }
 
 /* Handle the fault on write_protected page */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -179,7 +179,11 @@ static struct frame *vm_get_frame(void) {
 }
 
 /* Growing the stack. */
-static void vm_stack_growth(void *addr UNUSED) {}
+static void vm_stack_growth(void *addr UNUSED) {
+    // 스택 확장을 위한 익명페이지 할당
+    // 페이지폴트 발생 주소를 round down
+    vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, pg_round_down(addr), true, NULL, NULL);
+}
 
 /* Handle the fault on write_protected page */
 static bool vm_handle_wp(struct page *page UNUSED) {}


### PR DESCRIPTION
# `vm_stack_growth`
반환값이 `void`인 함수 특성상 할 게 그닥 많진 않았습니다

```c
static void vm_stack_growth(void *addr) {
    // 스택 확장을 위한 익명페이지 할당
    // 페이지폴트 발생 주소를 round down
    vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, pg_round_down(addr), true, NULL, NULL);
}
```