### PR TITLE
mmap 만 구현 - 리스트처리는 제외

### DIFF
--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -14,4 +14,19 @@ void process_activate(struct thread *next);
 static void argument_stack(char **argv, int argc, struct intr_frame *if_, void *buffer);
 /* 7.28 추가 자식 pid 구하기 */
 struct thread *get_child_with_pid(tid_t tid);
+
+#ifdef VM
+// 파일정보 관리용 구조체 선언
+struct file_aux {
+    struct file *file;          // 파일 주소
+    off_t ofs;                  // 파일 내 읽을 위치
+    size_t page_read_bytes;     // 읽을 바이트 수
+    size_t page_zero_bytes;     // zero 패딩할 바이트 수
+};
+
+bool lazy_load_segment(struct page *page, void *aux);
+#endif
+
 #endif /* userprog/process.h */
+
+

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -27,12 +27,8 @@
 
 
 // [0805] 파일정보 관리용 구조체 선언
-struct file_aux {
-    struct file *file;          // 파일 주소
-    off_t ofs;                  // 파일 내 읽을 위치
-    size_t page_read_bytes;     // 읽을 바이트 수
-    size_t page_zero_bytes;     // zero 패딩할 바이트 수
-};
+// userprog/process.h로 이사감
+
 #endif
 
 
@@ -796,7 +792,7 @@ static bool install_page(void *upage, void *kpage, bool writable) {
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 // 페이지 폴트 -> lazy_load 호출 -> aux 내용에 따라 물리프레임에 데이터 채워넣음
-static bool lazy_load_segment(struct page *page, void *aux) {
+bool lazy_load_segment(struct page *page, void *aux) {
 
     // aux 파싱
     /* TODO: Load the segment from the file */ 
@@ -811,7 +807,8 @@ static bool lazy_load_segment(struct page *page, void *aux) {
     free(aux);
 
     // 파일 읽기
-    if (file_read_at(_file, kpage, _page_read_bytes, _ofs) != _page_read_bytes){
+    size_t result;
+    if ((result = file_read_at(_file, kpage, _page_read_bytes, _ofs)) != _page_read_bytes){
         return false;   // 지정한 바이트와 실제 읽은 바이트가 동일해야 함
     }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -356,10 +356,17 @@ int read(int fd, void *buffer, unsigned size) {  // Case : 9
         exit(-1);
     }
 
+    // pt-write-code2.c: 쓰기 권한 체크
+    struct page *page = spt_find_page(&thread_current()->spt,pg_round_down(buffer));
+    if (!page || !page -> writable){
+        exit(-1);
+    }
+
     // read-bad-fd.c : fd 범위 벗어나는지 체크
     if (fd < 0 || fd >= FDT_MAX_SIZE) {
         exit(-1);
     }
+
 
     struct thread *cur_thread = thread_current();  // 현재 쓰레드
     int bytes_read = 0;                            // 반환값에 쓸, 읽어온 바이트 수

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -1,4 +1,5 @@
 #include "userprog/syscall.h"
+#include "userprog/process.h"
 
 #include <stdio.h>
 #include <syscall-nr.h>
@@ -10,6 +11,7 @@
 #include "threads/interrupt.h"
 #include "threads/loader.h"
 #include "threads/thread.h"
+#include "threads/malloc.h"
 #include "userprog/gdt.h"
 #include "vm/vm.h"
 
@@ -43,6 +45,7 @@ int open(const char *file_name);
 int filesize(int fd);
 int read(int fd, void *buffer, unsigned size);
 void close(int fd);
+void *mmap(void *addr, size_t length, int writable, int fd, off_t offset);
 /* ======================================*/
 
 /* System call.
@@ -123,6 +126,12 @@ void syscall_handler(struct intr_frame *f UNUSED) {
             break;
         case SYS_CLOSE:  // case : 13
             close(f->R.rdi);
+            break;
+        case SYS_MMAP:  // case : 14
+            f->R.rax = (uint64_t)mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
+            break;
+        case SYS_MUNMAP:    // case : 15
+            // 임시
             break;
         // case SYS_DUP2:
         //     f->R.rax = dup2 (f->R.rdi, f->R.rsi);
@@ -465,6 +474,59 @@ void close(int fd) {  // Case : 13
 
     // 4. FDT 슬롯 비우기
     cur->fdt[fd] = NULL;
+}
+
+void *mmap(void *addr, size_t length, int writable, int fd, off_t ofs){
+    // 실패 조건: 주소 NULL / 크기 0 / page-aligned되지 않은 주소 / invalid offset
+    if (addr == NULL || length == 0 || (uintptr_t)addr % PGSIZE != 0 || ofs % PGSIZE != 0 ){
+        return NULL;
+    }
+
+    // 실패 조건: 커널 영역에 주소가 겹침
+    if (is_kernel_vaddr(addr) || is_kernel_vaddr(addr + length - 1)){
+        return NULL;
+    }
+
+    // 파일찾기
+    struct thread *cur = thread_current();
+    struct file *map_file = cur -> fdt[fd];
+
+    // 실패 조건: fd에 대응하는 파일이 없거나, 파일의 길이가 0인 경우
+    if (map_file == NULL || file_length(map_file) == 0){
+        return NULL;
+    }
+
+    map_file = file_reopen(map_file);
+    if (map_file == NULL){
+        return NULL;
+    }
+
+    size_t read_bytes = file_length(map_file);
+    void *upage = addr;
+
+    // 반복해서 페이지할당 요청
+    while (read_bytes > 0) {
+        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+        size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+        struct file_aux *aux = malloc(sizeof(struct file_aux));
+        aux -> file = map_file;
+        aux -> ofs = ofs;
+        aux -> page_read_bytes = page_read_bytes;
+        aux -> page_zero_bytes = page_zero_bytes;
+
+        if (!vm_alloc_page_with_initializer(VM_FILE, upage, writable, lazy_load_segment, aux)){
+            free(aux);
+            return NULL;
+        }
+        
+        read_bytes -= page_read_bytes;
+        upage += PGSIZE;
+        ofs += page_read_bytes;
+    } 
+
+    // 리스트 삽입 나중에
+    return addr;
 }
 
 //////////////////////////////////////////////////////////////////

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -23,6 +23,7 @@ bool file_backed_initializer(struct page *page, enum vm_type type, void *kva) {
     page->operations = &file_ops;
 
     struct file_page *file_page = &page->file;
+    return true;
 }
 
 /* Swap in the page by read contents from the file. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -286,7 +286,7 @@ bool vm_claim_page(void *va UNUSED) {
     struct page *page = NULL;
 
     /* TODO: Fill this function */    
-    // spt는 구조체로 선언되어 있어서 &(주소 연산자)를 붙여줌.
+    // spt는 구조체로 선언되 어 있어서 &(주소 연산자)를 붙여줌.
     // EXPECT: 유저 영역의 va와 spt 정보를 넘겨주면 spt에 해당 주소에 대한 정보가 있으면 페이지를 가져올 것을 기대함.
     page = spt_find_page(&thread_current()->spt,va);
 


### PR DESCRIPTION
`mmap` 통해 file-backed 페이지를 초기화하고 파일 로딩하는 것까지 구현했습니다

리스트는 구현하지 않았습니다 (그래서 구조체 쪽에선 수정사항이 없습니다)

# `syscall_handler`
```c
case SYS_MMAP:  // case : 14
            f->R.rax = (uint64_t)mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
            break;
case SYS_MUNMAP:    // case : 15
            // 임시
            break;
```

# `mmap`

```c
void *mmap(void *addr, size_t length, int writable, int fd, off_t ofs){
    // 실패 조건: 주소 NULL / 크기 0 / page-aligned되지 않은 주소 / invalid offset
    if (addr == NULL || length == 0 || (uintptr_t)addr % PGSIZE != 0 || ofs % PGSIZE != 0 ){
        return NULL;
    }

    // 실패 조건: 커널 영역에 주소가 겹침
    if (is_kernel_vaddr(addr) || is_kernel_vaddr(addr + length - 1)){
        return NULL;
    }

    // 파일찾기
    struct thread *cur = thread_current();
    struct file *map_file = cur -> fdt[fd];

    // 실패 조건: fd에 대응하는 파일이 없거나, 파일의 길이가 0인 경우
    if (map_file == NULL || file_length(map_file) == 0){
        return NULL;
    }

    map_file = file_reopen(map_file);
    if (map_file == NULL){
        return NULL;
    }

    size_t read_bytes = file_length(map_file);
    void *upage = addr;

    // 반복해서 페이지할당 요청
    while (read_bytes > 0) {
        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
        size_t page_zero_bytes = PGSIZE - page_read_bytes;

        struct file_aux *aux = malloc(sizeof(struct file_aux));
        aux -> file = map_file;
        aux -> ofs = ofs;
        aux -> page_read_bytes = page_read_bytes;
        aux -> page_zero_bytes = page_zero_bytes;

        if (!vm_alloc_page_with_initializer(VM_FILE, upage, writable, lazy_load_segment, aux)){
            free(aux);
            return NULL;
        }
        
        read_bytes -= page_read_bytes;
        upage += PGSIZE;
        ofs += page_read_bytes;
    } 

    // 리스트 삽입 나중에
    return addr;
}
```

# 테스트 통과현황
```c
TOTAL TESTING SCORE: 79.5%

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

SUMMARY BY TEST SET

Test Set                                      Pts Max  % Ttl  % Max
--------------------------------------------- --- --- ------ ------
tests/threads/Rubric.alarm                      7/  7   1.0%/  1.0%
tests/threads/Rubric.priority                  25/ 25   1.0%/  1.0%
tests/userprog/Rubric.functionality            40/ 40   8.0%/  8.0%
tests/userprog/Rubric.robustness               40/ 40   5.0%/  5.0%
tests/vm/Rubric.functionality                  54/ 82  39.5%/ 60.0%
tests/vm/Rubric.robustness                     29/ 29  20.0%/ 20.0%
tests/filesys/base/Rubric                      17/ 17   5.0%/  5.0%
tests/vm/cow/Rubric                             0/  1   0.0%/ 25.0%
--------------------------------------------- --- --- ------ ------
Total                                                  79.5%/125.0%

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

SUMMARY OF INDIVIDUAL TESTS

Functionality and robustness of alarm clock (tests/threads/Rubric.alarm):
	     1/ 1 tests/threads/alarm-single
	     1/ 1 tests/threads/alarm-multiple
	     1/ 1 tests/threads/alarm-simultaneous
	     2/ 2 tests/threads/alarm-priority

	     1/ 1 tests/threads/alarm-zero
	     1/ 1 tests/threads/alarm-negative

	- Section summary.
	      6/  6 tests passed
	      7/  7 points subtotal

Functionality of priority scheduler (tests/threads/Rubric.priority):
	     1/ 1 tests/threads/priority-change
	     1/ 1 tests/threads/priority-preempt

	     1/ 1 tests/threads/priority-fifo
	     2/ 2 tests/threads/priority-sema
	     2/ 2 tests/threads/priority-condvar

	     2/ 2 tests/threads/priority-donate-one
	     3/ 3 tests/threads/priority-donate-multiple
	     3/ 3 tests/threads/priority-donate-multiple2
	     3/ 3 tests/threads/priority-donate-nest
	     3/ 3 tests/threads/priority-donate-chain
	     2/ 2 tests/threads/priority-donate-sema
	     2/ 2 tests/threads/priority-donate-lower

	- Section summary.
	     12/ 12 tests passed
	     25/ 25 points subtotal

Functionality of system calls (tests/userprog/Rubric.functionality):
	- Test argument passing on Pintos command line.
	     1/ 1 tests/userprog/args-none
	     1/ 1 tests/userprog/args-single
	     1/ 1 tests/userprog/args-multiple
	     1/ 1 tests/userprog/args-many
	     1/ 1 tests/userprog/args-dbl-space

	- Test "create" system call.
	     1/ 1 tests/userprog/create-empty
	     1/ 1 tests/userprog/create-long
	     1/ 1 tests/userprog/create-normal
	     1/ 1 tests/userprog/create-exists

	- Test "open" system call.
	     1/ 1 tests/userprog/open-missing
	     1/ 1 tests/userprog/open-normal
	     1/ 1 tests/userprog/open-twice

	- Test "read" system call.
	     1/ 1 tests/userprog/read-normal
	     1/ 1 tests/userprog/read-zero

	- Test "write" system call.
	     1/ 1 tests/userprog/write-normal
	     1/ 1 tests/userprog/write-zero

	- Test "close" system call.
	     1/ 1 tests/userprog/close-normal

	- Test "fork" system call.
	     1/ 1 tests/userprog/fork-once
	     1/ 1 tests/userprog/fork-multiple
	     2/ 2 tests/userprog/fork-close
	     2/ 2 tests/userprog/fork-read

	- Test "exec" system call.
	     1/ 1 tests/userprog/exec-once
	     1/ 1 tests/userprog/exec-arg
	     2/ 2 tests/userprog/exec-read

	- Test "wait" system call.
	     1/ 1 tests/userprog/wait-simple
	     1/ 1 tests/userprog/wait-twice

	- Test "exit" system call.
	     1/ 1 tests/userprog/exit

	- Test "halt" system call.
	     1/ 1 tests/userprog/halt

	- Test recursive execution of user programs.
	     2/ 2 tests/userprog/fork-recursive
	     2/ 2 tests/userprog/multi-recurse

	- Test read-only executable feature.
	     1/ 1 tests/userprog/rox-simple
	     2/ 2 tests/userprog/rox-child
	     2/ 2 tests/userprog/rox-multichild

	- Section summary.
	     33/ 33 tests passed
	     40/ 40 points subtotal

Robustness of system calls (tests/userprog/Rubric.robustness):
	- Test robustness of file descriptor handling.
	     1/ 1 tests/userprog/close-bad-fd
	     1/ 1 tests/userprog/close-twice
	     1/ 1 tests/userprog/read-bad-fd
	     1/ 1 tests/userprog/read-stdout
	     1/ 1 tests/userprog/write-bad-fd
	     1/ 1 tests/userprog/write-stdin
	     2/ 2 tests/userprog/multi-child-fd

	- Test robustness of pointer handling.
	     1/ 1 tests/userprog/create-bad-ptr
	     1/ 1 tests/userprog/exec-bad-ptr
	     1/ 1 tests/userprog/open-bad-ptr
	     1/ 1 tests/userprog/read-bad-ptr
	     1/ 1 tests/userprog/write-bad-ptr

	- Test robustness of buffer copying across page boundaries.
	     2/ 2 tests/userprog/create-bound
	     2/ 2 tests/userprog/open-boundary
	     2/ 2 tests/userprog/read-boundary
	     2/ 2 tests/userprog/write-boundary
	     2/ 2 tests/userprog/fork-boundary
	     2/ 2 tests/userprog/exec-boundary

	- Test handling of null pointer and empty strings.
	     1/ 1 tests/userprog/create-null
	     1/ 1 tests/userprog/open-null
	     1/ 1 tests/userprog/open-empty

	- Test robustness of "fork", "exec" and "wait" system calls.
	     2/ 2 tests/userprog/exec-missing
	     2/ 2 tests/userprog/wait-bad-pid
	     2/ 2 tests/userprog/wait-killed

	- Test robustness of exception handling.
	     1/ 1 tests/userprog/bad-read
	     1/ 1 tests/userprog/bad-write
	     1/ 1 tests/userprog/bad-jump
	     1/ 1 tests/userprog/bad-read2
	     1/ 1 tests/userprog/bad-write2
	     1/ 1 tests/userprog/bad-jump2

	- Section summary.
	     30/ 30 tests passed
	     40/ 40 points subtotal

Functionality of virtual memory subsystem (tests/vm/Rubric.functionality):
	- Test stack growth.
	     2/ 2 tests/vm/pt-grow-stack
	     4/ 4 tests/vm/pt-grow-stk-sc
	     3/ 3 tests/vm/pt-big-stk-obj

	- Test paging behavior.
	     1/ 1 tests/vm/page-linear
	     4/ 4 tests/vm/page-parallel
	     2/ 2 tests/vm/page-shuffle
	     2/ 2 tests/vm/page-merge-seq
	     5/ 5 tests/vm/page-merge-par
	  ** 0/ 5 tests/vm/page-merge-mm
	  ** 0/ 5 tests/vm/page-merge-stk

	- Test "mmap" system call.
	     1/ 1 tests/vm/mmap-read
	  ** 0/ 3 tests/vm/mmap-write
	     2/ 2 tests/vm/mmap-ro
	     2/ 2 tests/vm/mmap-shuffle
	     1/ 1 tests/vm/mmap-twice
	     2/ 2 tests/vm/mmap-unmap
	  ** 0/ 2 tests/vm/mmap-exit
	     3/ 3 tests/vm/mmap-clean
	     2/ 2 tests/vm/mmap-close
	     2/ 2 tests/vm/mmap-remove
	  ** 0/ 1 tests/vm/mmap-off

	- Test memory swapping
	  ** 0/ 3 tests/vm/swap-anon
	  ** 0/ 3 tests/vm/swap-file
	  ** 0/ 6 tests/vm/swap-iter
	     8/ 8 tests/vm/swap-fork

	- Test lazy loading
	     4/ 4 tests/vm/lazy-anon
	     4/ 4 tests/vm/lazy-file

	- Section summary.
	     19/ 27 tests passed
	     54/ 82 points subtotal

Robustness of virtual memory subsystem (tests/vm/Rubric.robustness):
	- Test robustness of page table support.
	     1/ 1 tests/vm/pt-bad-addr
	     3/ 3 tests/vm/pt-bad-read
	     1/ 1 tests/vm/pt-write-code
	     3/ 3 tests/vm/pt-write-code2
	     2/ 2 tests/vm/pt-grow-bad

	- Test robustness of "mmap" system call.
	     1/ 1 tests/vm/mmap-bad-fd
	     1/ 1 tests/vm/mmap-bad-fd2
	     1/ 1 tests/vm/mmap-bad-fd3

	     3/ 3 tests/vm/mmap-inherit
	     1/ 1 tests/vm/mmap-null
	     1/ 1 tests/vm/mmap-zero
	     2/ 2 tests/vm/mmap-zero-len

	     1/ 1 tests/vm/mmap-misalign

	     1/ 1 tests/vm/mmap-over-code
	     1/ 1 tests/vm/mmap-over-data
	     2/ 2 tests/vm/mmap-over-stk
	     1/ 1 tests/vm/mmap-overlap
	     1/ 1 tests/vm/mmap-bad-off
	     2/ 2 tests/vm/mmap-kernel

	- Section summary.
	     19/ 19 tests passed
	     29/ 29 points subtotal

Functionality of base file system (tests/filesys/base/Rubric):
	- Test basic support for small files.
	     1/ 1 tests/filesys/base/sm-create
	     1/ 1 tests/filesys/base/sm-full
	     1/ 1 tests/filesys/base/sm-random
	     1/ 1 tests/filesys/base/sm-seq-block
	     2/ 2 tests/filesys/base/sm-seq-random

	- Test basic support for large files.
	     1/ 1 tests/filesys/base/lg-create
	     1/ 1 tests/filesys/base/lg-full
	     1/ 1 tests/filesys/base/lg-random
	     1/ 1 tests/filesys/base/lg-seq-block
	     2/ 2 tests/filesys/base/lg-seq-random

	- Test synchronized multiprogram access to files.
	     2/ 2 tests/filesys/base/syn-read
	     2/ 2 tests/filesys/base/syn-write
	     1/ 1 tests/filesys/base/syn-remove

	- Section summary.
	     13/ 13 tests passed
	     17/ 17 points subtotal

Functionality of copy-on-write (tests/vm/cow/Rubric):
	- Basic functionality for copy-on-write.
	  ** 0/ 1 tests/vm/cow/cow-simple

	- Section summary.
	      0/  1 tests passed
	      0/  1 points subtotal
```
