### PR TITLE
munmap, page-merge-stk

### DIFF
--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -8,8 +8,18 @@ enum vm_type;
 
 struct file_page {};
 
+struct mmap_file{
+    void *addr;         // 시작 페이지의 주소
+    struct file *file;  // 파일 주소
+    struct list_elem elem;   // struct thread의 mmap_list 삽입용도
+    size_t length;      // 매핑된 영역 크기
+    size_t ofs;         // offset
+};
+
+
 void vm_file_init(void);
 bool file_backed_initializer(struct page *page, enum vm_type type, void *kva);
+void munmap_file(struct mmap_file *mf);
 void *do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset);
 void do_munmap(void *va);
 #endif

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -414,6 +414,22 @@ void process_exit(void) {
      * TODO: project2/process_termination.html).
      * TODO: We recommend you to implement process resource cleanup here. */
 
+    #ifdef VM
+
+    // 모든 매핑 unmap
+    while (!list_empty(&curr->mmap_list)){
+        // struct thread의 mmap_list에서 빼기
+        struct list_elem *e = list_pop_front(&curr->mmap_list);
+        struct mmap_file *mf = list_entry(e, struct mmap_file, elem);
+        // 파일 unmapping 수행
+        munmap_file(mf);
+        // file을 close하고, struct mmap_file을 free
+        file_close(mf -> file);
+        free(mf);
+    }
+
+    #endif
+
     // 모든 FDT 닫기
     for (int i = 2; i < FDT_MAX_SIZE; i++) {
         if (curr->fdt[i] != NULL) {
@@ -444,6 +460,10 @@ static void process_cleanup(void) {
 
 #ifdef VM
     supplemental_page_table_kill(&curr->spt);
+    struct list_elem *e;
+    struct mmap_file *mf;
+    
+    
 #endif
 
     uint64_t *pml4;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -131,7 +131,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
             f->R.rax = (uint64_t)mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
             break;
         case SYS_MUNMAP:    // case : 15
-            // 임시
+            munmap(f->R.rdi);
             break;
         // case SYS_DUP2:
         //     f->R.rax = dup2 (f->R.rdi, f->R.rsi);
@@ -505,7 +505,15 @@ void *mmap(void *addr, size_t length, int writable, int fd, off_t ofs){
 
     return do_mmap(addr, length, writable, map_file, ofs);
 
-    
+}
+
+void munmap(void *addr){
+    // 실패 조건
+    if (addr == NULL || is_kernel_vaddr(addr)){
+        return;
+    }
+
+    do_munmap(addr);
 }
 
 //////////////////////////////////////////////////////////////////

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -101,7 +101,6 @@ void munmap_file(struct mmap_file *mf){
     void *upage = mf -> addr;
     off_t ofs = mf -> ofs;
     struct page *c_page;
-    size_t result;
 
     while (length > 0){
         

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -1,16 +1,12 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
+#include "vm/file.h"
 #include "userprog/process.h"
 #include "threads/vaddr.h"
+#include "threads/mmu.h"
+#include "threads/malloc.h"
 
-struct mmap_file{
-    void *addr;         // 시작 페이지의 주소
-    struct file *file;  // 파일 주소
-    struct list_elem elem;   // struct thread의 mmap_list 삽입용도
-    size_t length;      // 매핑된 영역 크기
-    size_t ofs;         // offset
-};
 
 static bool file_backed_swap_in(struct page *page, void *kva);
 static bool file_backed_swap_out(struct page *page);
@@ -60,6 +56,7 @@ void *do_mmap(void *addr, size_t length, int writable, struct file *file, off_t 
 
     size_t read_bytes = file_length(file);
     void *upage = addr;
+    off_t _ofs = ofs;
 
     // 반복해서 페이지할당 요청
     while (read_bytes > 0) {
@@ -68,7 +65,7 @@ void *do_mmap(void *addr, size_t length, int writable, struct file *file, off_t 
 
         struct file_aux *aux = malloc(sizeof(struct file_aux));
         aux -> file = file;
-        aux -> ofs = ofs;
+        aux -> ofs = _ofs;
         aux -> page_read_bytes = page_read_bytes;
         aux -> page_zero_bytes = page_zero_bytes;
 
@@ -79,7 +76,7 @@ void *do_mmap(void *addr, size_t length, int writable, struct file *file, off_t 
         
         read_bytes -= page_read_bytes;
         upage += PGSIZE;
-        ofs += page_read_bytes;
+        _ofs += page_read_bytes;
     } 
 
     // mmap_file 구조체 만들고 삽입
@@ -95,5 +92,83 @@ void *do_mmap(void *addr, size_t length, int writable, struct file *file, off_t 
     return addr;
 }
 
+// 특정 mmap_file에 대해 unmap 수행
+void munmap_file(struct mmap_file *mf){
+    // 페이지 단위 반복
+    struct thread *cur = thread_current();
+    size_t length = mf -> length;
+    size_t write_bytes = file_length(mf -> file);
+    void *upage = mf -> addr;
+    off_t ofs = mf -> ofs;
+    struct page *c_page;
+    size_t result;
+
+    while (length > 0){
+        
+        size_t page_write_bytes = write_bytes < PGSIZE ? write_bytes : PGSIZE;
+
+        size_t result;
+        // 더티 비트가 1인 경우, 파일에 다시 쓰기
+        if (pml4_is_dirty(cur -> pml4, upage)){
+            result = file_write_at(mf -> file, upage, page_write_bytes, ofs);
+            if (result != page_write_bytes){
+                return;
+            };
+        }
+
+        c_page = spt_find_page(&cur -> spt, upage);
+        if (c_page == NULL){
+            return;
+        }
+
+        // struct frame 존재하면, free해 줌
+        if (c_page -> frame != NULL){
+            // 해줄 필요 없었음 double free 발생
+            // palloc_free_page(c_page -> frame -> kva);
+            free(c_page -> frame);
+        }
+
+        if (c_page != NULL){
+            // 뭔가 동작상 문제가 있는 듯함 아래 함수가?
+            // spt_remove_page(&cur -> spt, c_page);
+            hash_delete(&(thread_current() -> spt.pages), &(c_page->hash_elem));
+            free(c_page);
+        }
+        
+
+        length -= PGSIZE;
+        write_bytes -= page_write_bytes;
+        upage += PGSIZE;
+        ofs += page_write_bytes;
+    }
+}
+
 /* Do the munmap */
-void do_munmap(void *addr) {}
+void do_munmap(void *addr) {
+    // 매핑 정보 검색
+
+    struct thread *cur = thread_current();
+    struct list_elem *e;
+    bool found = false;
+    struct mmap_file *mf;
+
+    for (e = list_begin(&cur->mmap_list); e != list_end(&cur->mmap_list); e = list_next(e)){
+        mf = list_entry(e, struct mmap_file, elem);
+        if (mf -> addr == addr){
+            found = true;
+            break;
+        }
+    }
+
+    // 찾지 못한 경우 실패
+    if (!found){
+        return;
+    }
+    // 파일 unmapping 수행
+    munmap_file(mf);
+    // struct thread의 mmap_list에서 빼기
+    list_remove(&mf -> elem);
+    // file을 close하고, struct mmap_file을 free
+    file_close(mf -> file);
+    free(mf);
+}

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -241,7 +241,7 @@ bool vm_try_handle_fault(struct intr_frame *f , void *addr , bool user ,
         
         // page-merge-stack 테스트케이스 해결 위해선
         // addr <= rsp 는 빼 줘야 했었음
-        if ( rsp -8 <= addr && addr <= rsp && addr >= USER_STACK - (1<<20)){
+        if ( rsp -8 <= addr && addr >= USER_STACK - (1<<20)){
             
             // 스택 공간 할당
             vm_stack_growth(addr);
@@ -321,7 +321,7 @@ static bool vm_do_claim_page(struct page *page) {
     // FIX : 처음에는 frame->page를 넘겨줬는데, 유저 영역의 VA 와 커널 영역의 실제 메모리 주소를 매핑하는 것이므로 page->va로 변경 
     // FIX : 인자를 writable 로 넘겨주도록 수정
     if(!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)){  // true, false를 반환하므로, 실패 시 에러 처리
-        printf("Failed to Insert page table entry to map page's VA to frame's PA");
+        // printf("Failed to Insert page table entry to map page's VA to frame's PA");
         return false;
     }
     return swap_in(page, frame->kva);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -239,6 +239,8 @@ bool vm_try_handle_fault(struct intr_frame *f , void *addr , bool user ,
             rsp = thread_current()->user_rsp;
         }
         
+        // page-merge-stack 테스트케이스 해결 위해선
+        // addr <= rsp 는 빼 줘야 했었음
         if ( rsp -8 <= addr && addr <= rsp && addr >= USER_STACK - (1<<20)){
             
             // 스택 공간 할당


### PR DESCRIPTION
# `page-merge-stk`

```c
// vm.c 내 vm_try_handle_fault
if ( rsp -8 <= addr && addr >= USER_STACK - (1<<20)){
```
- `addr <= rsp` 조건을 제거해 줘야 통과가 되더군요.

# `do_munmap`

```c
void do_munmap(void *addr) {
    // 매핑 정보 검색

    struct thread *cur = thread_current();
    struct list_elem *e;
    bool found = false;
    struct mmap_file *mf;

    for (e = list_begin(&cur->mmap_list); e != list_end(&cur->mmap_list); e = list_next(e)){
        mf = list_entry(e, struct mmap_file, elem);
        if (mf -> addr == addr){
            found = true;
            break;
        }
    }

    // 찾지 못한 경우 실패
    if (!found){
        return;
    }
    // 파일 unmapping 수행
    munmap_file(mf);
    // struct thread의 mmap_list에서 빼기
    list_remove(&mf -> elem);
    // file을 close하고, struct mmap_file을 free
    file_close(mf -> file);
    free(mf);
}
```
- 현재 `struct thread`의 `mmap_list`에서, 매개변수 `addr`와 일치하는 `struct mmap_file`을 찾습니다.
- 찾으면 `munmap_file`로 처리 후, 리스트에서 제거 -> 파일 닫기 -> `struct mmap_file` free 해줍니다.

# `munmap_file`
```c
// 특정 mmap_file에 대해 unmap 수행
void munmap_file(struct mmap_file *mf){
    // 페이지 단위 반복
    struct thread *cur = thread_current();
    size_t length = mf -> length;
    size_t write_bytes = file_length(mf -> file);
    void *upage = mf -> addr;
    off_t ofs = mf -> ofs;
    struct page *c_page;
    size_t result;

    while (length > 0){

        size_t page_write_bytes = write_bytes < PGSIZE ? write_bytes : PGSIZE;

        size_t result;
        // 더티 비트가 1인 경우, 파일에 다시 쓰기
        if (pml4_is_dirty(cur -> pml4, upage)){
            result = file_write_at(mf -> file, upage, page_write_bytes, ofs);
           //  result: 실제로 write한 바이트 크기
            if (result != page_write_bytes){
                return;
            };
        }

        c_page = spt_find_page(&cur -> spt, upage);
        if (c_page == NULL){
            return;
        }

        // struct frame 존재하면, free해 줌
        if (c_page -> frame != NULL){
            // 해줄 필요 없었음 double free 발생
            // palloc_free_page(c_page -> frame -> kva);
            free(c_page -> frame);
        }

        if (c_page != NULL){
            // 뭔가 동작상 문제가 있는 듯함 아래 함수가?
            // spt_remove_page(&cur -> spt, c_page);
            hash_delete(&(thread_current() -> spt.pages), &(c_page->hash_elem));
            free(c_page);
        }


        length -= PGSIZE;
        write_bytes -= page_write_bytes;
        upage += PGSIZE;
        ofs += page_write_bytes;
    }
}
```
- 페이지 단위로, 더티비트가 1인 경우 `file_write_at`으로 파일에 다시 쓰기 연산 진행합니다.
- `file_write_at(mf -> file, upage, page_write_bytes, ofs);`
  - `upage`부터 `mf->file`의 `ofs`번째 바이트부터 `page_write_bytes`만큼 쓰기 연산
  - `page_write_bytes < PGSIZE`인 경우 `page_write_bytes`만큼만 쓰고, 뒤의 제로패딩은 무시됩니다.
- 이후 필요한 자원을 free해 줍니다.

 # 종료시 모든 매핑 파일 unmap
```c
// process.c 내 process_exit
    #ifdef VM

    // 모든 매핑 unmap
    while (!list_empty(&curr->mmap_list)){
        // struct thread의 mmap_list에서 빼기
        struct list_elem *e = list_pop_front(&curr->mmap_list);
        struct mmap_file *mf = list_entry(e, struct mmap_file, elem);
        // 파일 unmapping 수행
        munmap_file(mf);
        // file을 close하고, struct mmap_file을 free
        file_close(mf -> file);
        free(mf);
    }

    #endif
```
- 모든 파일에 대해 `munmap_file`을 반복 호출해 모든 매핑 파일을 언맵합니다.
- `mmap_exit` 테스트 케이스 통과에 필요했습니다.