### PR TITLE
feat : file swapping

### DIFF
--- a/pintos/filesys/file.c
+++ b/pintos/filesys/file.c
@@ -77,6 +77,8 @@ off_t file_read(struct file *file, void *buffer, off_t size) {
  * Returns the number of bytes actually read,
  * which may be less than SIZE if end of file is reached.
  * The file's current position is unaffected. */
+// 파일의 오프셋부터,버퍼로 ,SIZE 만큼 읽어온다.
+// 실제로 읽은 바이트 수 반환
 off_t file_read_at(struct file *file, void *buffer, off_t size, off_t file_ofs) {
     return inode_read_at(file->inode, buffer, size, file_ofs);
 }

--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -6,7 +6,15 @@
 struct page;
 enum vm_type;
 
-struct file_page {};
+// [08.12] 구조체 내용 추가 
+// 페이지폴트가 발생했을때 필요한 정보
+struct file_page {
+    bool is_file;                  // 파일의 존재여부
+    struct file *file;          // 파일 주소
+    off_t ofs;                  // 파일 내 읽을 위치
+    size_t page_read_bytes;     // 읽을 바이트 수
+    size_t page_zero_bytes;     // zero 패딩할 바이트 수
+};
 
 struct mmap_file{
     void *addr;         // 시작 페이지의 주소

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -5,8 +5,7 @@
 #include <bitmap.h>
 
 //[08.11] 헤더 , 전역변수 추가
-#include "bitmap.h"
-#include "mmu.h"
+#include "threads/mmu.h"
 struct bitmap* global_bitmap;
 
 /* DO NOT MODIFY BELOW LINE */


### PR DESCRIPTION
파일 `swap_out` , `swap_in` 기능 구현했습니다. 
`file_backed_initializer` 는 상록이가 보내준것과 완전히 동일해서
`swap_out`, `swap_in` 만 봐주셔도 됩니다.

`2025.08.12` -  수정
---
## 0. `struct file_page`  (상록)
```c
struct file_page {
    bool is_file;                  // 파일의 존재여부
    struct file *file;          // 파일 주소
    off_t ofs;                  // 파일 내 읽을 위치
    size_t page_read_bytes;     // 읽을 바이트 수
    size_t page_zero_bytes;     // zero 패딩할 바이트 수
};
```


## 1. `file_backed_swap_out`
```c
static bool file_backed_swap_out(struct page *page) {
    
    struct file_page *file_page  = &page->file;
    struct frame* victim = page->frame; //희생 프레임은 이미 결정된 상태
    
    // Dirty bit == 1
    if(pml4_is_dirty(victim->th->pml4,page->va)){

        //인자 순서: 파일,버퍼(RAM),사이즈,오프셋
        if(!file_write_at(file_page->file,victim->kva,file_page->page_read_bytes,file_page->ofs)==file_page->page_read_bytes){
            return false;
        }

        //더티비트 0 으로 수정
        pml4_set_dirty(victim->th->pml4, page->va, false);
    }

    // Dirty bit == 0  일때는 그대로
   
    return true;     
}
```

## 2. `file_backed_swap_in`
```c
static bool file_backed_swap_in(struct page *page, void *kva) {
    struct file_page *file_page  = &page->file;

    //파일을 읽어서 버퍼에 복사
    if(!file_read_at(file_page->file,kva,file_page->page_read_bytes,file_page->ofs) == file_page->page_read_bytes){
        return false;
    }

    // 첫 인자부터 , 0으로, zero_bytes 만큼 채우기 
    size_t zero_bytes = PGSIZE - file_page->page_read_bytes;
    memset((char*)kva + file_page->page_read_bytes,  0,  zero_bytes);

    return true;    
}
```